### PR TITLE
feat: add flake8-pyproject dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Orquestra packages. The tools which this package tracks versions of are:
 
 - black
 - flake8
+- Flake8-pyproject
 - isort
 - mypy
 - pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ python_requires = >=3.8,!=3.9.7,<3.11
 install_requires =
     black~=22.3
     flake8~=3.9.0
+    Flake8-pyproject>=0.9.0
     isort~=5.9.0
     mypy~=0.910
     pytest~=6.2


### PR DESCRIPTION
## Description

Added a new dependency, [Flake8-pyproject](https://pypi.org/project/Flake8-pyproject/). This is needed to put flake8 config in `pyproject.toml` as `flake8` itself does not support `pyproject.toml`.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
