### PR TITLE
chore: Remove Python 3.11 upper bound

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ classifiers =
 
 
 [options]
-python_requires = >=3.8,!=3.9.7,<3.11
+python_requires = >=3.9,!=3.9.7
 
 install_requires =
     black~=22.3


### PR DESCRIPTION
## Description

In order to support Python 3.11, we need to remove the upper bound on the Python version.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
